### PR TITLE
Refactor/Disabling class documentation Rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-22
 
 DEPENDENCIES
   rubocop

--- a/config/base.yml
+++ b/config/base.yml
@@ -51,9 +51,7 @@ Style/IfUnlessModifier:
     - config/**/*
 
 Style/Documentation:
-  Exclude:
-    - config/**/*
-    - db/**/*
+  Enabled: false
 
 # Metrics
 


### PR DESCRIPTION
We are defining class documentation which gives errors in CI, so we disabled it permanently until we agree to use it again.