### PR TITLE
Feat: Indentation fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,51 +1,55 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
-    minitest (5.17.0)
+    minitest (5.18.0)
     parallel (1.22.1)
-    parser (3.2.0.0)
+    parser (3.2.2.0)
       ast (~> 2.4.1)
-    rack (3.0.3)
+    rack (3.0.7)
     rainbow (3.1.1)
-    regexp_parser (2.6.1)
+    regexp_parser (2.7.0)
     rexml (3.2.5)
-    rubocop (1.43.0)
+    rubocop (1.49.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.24.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.15.2)
+    rubocop-ast (1.28.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.17.1)
+      rubocop (~> 1.41)
+    rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.17.4)
+    rubocop-rails (2.18.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    rubocop-rspec (2.17.0)
+    rubocop-rspec (2.19.0)
       rubocop (~> 1.33)
-    ruby-progressbar (1.11.0)
-    tzinfo (2.0.5)
+      rubocop-capybara (~> 2.17)
+    ruby-progressbar (1.13.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-22
 
@@ -56,4 +60,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.2.17
+   2.4.1

--- a/config/base.yml
+++ b/config/base.yml
@@ -35,10 +35,6 @@ Layout/MultilineMethodCallIndentation:
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
-
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -26,6 +26,9 @@ Lint/AmbiguousBlockAssociation:
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/FirstMethodArgumentLineBreak:
   AllowMultilineFinalElement: true
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -26,6 +26,15 @@ Lint/AmbiguousBlockAssociation:
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
+Layout/FirstMethodArgumentLineBreak:
+  AllowMultilineFinalElement: true
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table


### PR DESCRIPTION
### 🗒️ Description

Just a small PR fixing some of the cops that create really wild rivers in the code.

The main changes are:

#### Removing hash table alignment

No more value alignment, it's consistent with JSON/YAML and doesn't create big diffs on adding long-lines to hashes.

```rb
# before
{
  alpha:          0,
  bravo:          1,
  nested_charlie: {
    value: 3
  },
  echo:           {
    value: 4
  }
}

# after
{
  alpha: 0,
  bravo: 1,
  nested_charlie: {
    value: 3,
  },
  echo: {
    value: 4
  }
}
```

#### Changed multi-lines to not do first-arg alignment

Instead fall to fixed indentation (no more big indented second-line params)

```rb
# before
def perform_request
   client.post(Settings.apis.rapid.drivers.create_url,
               headers:,
               body:    {
                 userId: user_id,
                 tier:
               })

# after
def perform_request
  client.post(Settings.apis.rapid.drivers.create_url,
    headers:,
    body: {
      userId: user_id,
      tier:
    }
  )
end
```

#### Allow final hash-multilines 

These are often useful for option-arguments, particularly useful in specs but basically, final arguments that are hashes can be spread like below:

```rb
client.call(url, :get, {
  headers: { **auth_headers, **cache_headers },
  timeout: 120.seconds
})
```