### PR TITLE
Feat: team-session adjustments

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -69,10 +69,10 @@ Metrics/BlockLength:
     - config/**/*
 
 Metrics/ClassLength:
-  Max: 120
+  Enabled: false
 
 Metrics/MethodLength:
-  Max: 16
+  Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
   Max: 8

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,10 +1,13 @@
 # Seperate config file for the rubocop-rspec cops
 
 RSpec/NestedGroups:
-  Max: 5
+  Max: 7
 
 RSpec/MultipleExpectations:
   Enabled: false
 
-RSpec/ExampleLength:
+RSpec/MultipleMemoizedHelpers:
   Max: 10
+
+RSpec/ExampleLength:
+  Enabled: false


### PR DESCRIPTION
We removed length cops as we found they were often restrictive and not very practical in the majority of our BP projects. The rspec NestedGroups and MultipleMemoizedHelpers were both bumped up to 7 and 10 respectively.