### PR TITLE
feat: remove super() checks in initializers

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -20,6 +20,8 @@ AllCops:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
+Lint/MissingSuper:
+  Enabled: false
 
 # Layout
 


### PR DESCRIPTION
The `super()` in initializers in child classes are not _always_ required. Hence, I believe this should be optional and should not be picked up by RC. 

Example code where RC asks for `super()` but it is not required. 


```ruby
# frozen_string_literal: true

module Loyalty
  class V6LoyaltyRewardsCard
    class Base
      def state
        raise NotImplementedError, "Override in subclass"
      end

      def state_attributes
        raise NotImplementedError, "Override in subclass"
      end

      def activity_history
        {
          text: I18n.t("everyday_rewards.rewards_screen.activity_history_text"),
          url:  Settings.everyday_rewards.activity_history_url

        }
      end
    end

    class Empty < Base
      def state
        "LOYALTY_EMPTY"
      end

      def state_attributes
        {
          primary_text: I18n.t("everyday_rewards.rewards_screen.loyalty_empty_text")
        }
      end

      def activity_history
        raise NoMethodError, "Empty rewards card does not have access to activity_history"
      end
    end

    class Operating < Base
      def initialize(everyday_rewards_id:, balances:, cpl_discount:)
        @everyday_rewards_id = everyday_rewards_id
        @balances = balances
        @cpl_discount = cpl_discount
      end

      def state
        "LOYALTY_OPERATING"
      end

      def state_attributes
        {
          everyday_rewards_id: @everyday_rewards_id,
          cpl_discount: @cpl_discount,
          activity_history: activity_history,
          balances: @balances
        }
      end
    end

    class Error < Base
      def initialize(error_text:)
        @error_text = error_text
      end

      def state
        "LOYALTY_ERROR"
      end

      def state_attributes
        {
          primary_text: @error_text,
          error_image_url: "#{ApplicationConfig::EVERYDAY_REWARDS_IMAGE_BASE_URL}/#{Settings.everyday_rewards.rewards_error_image}",
          activity_history: activity_history
        }
      end
    end
  end
end

``` 