### PR TITLE
Bump up version to 1.3.1 as 1.3.0 is yanked

### DIFF
--- a/paperkite-rubocop.gemspec
+++ b/paperkite-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name    = "paperkite-rubocop"
-  spec.version = "1.3.0"
+  spec.version = "1.3.1"
   spec.authors = ["Montgomery Anderson"]
   spec.email   = "montgomery.anderson@paperkite.co.nz"
 


### PR DESCRIPTION
Updated gem version to 1.3.1, as 1.3.0 was yanked and can not be resued in rubygems.org