### PR TITLE
Chore/update rubocop to 1.64.0

### DIFF
--- a/paperkite-rubocop.gemspec
+++ b/paperkite-rubocop.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "~> 1.16.0"
   spec.add_development_dependency "rubocop-rails",       "~> 2.18.0"
   spec.add_development_dependency "rubocop-rspec",       "~> 2.19.0"
-  spec.metadata["rubygems_mfa_required"] = "true"
+  spec.metadata["rubygems_mfa_required"] = "false"
 end


### PR DESCRIPTION
Originally the mfc is not required. but after changing the specification file, rubocop changed it to true. 
roll back to false, so we can push the gem