### PR TITLE
Use trusted publishing for deployment to RubyGems

### DIFF
--- a/.github/workflows/rubygems-deployment.yaml
+++ b/.github/workflows/rubygems-deployment.yaml
@@ -9,17 +9,10 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
-    - name: Install dependencies
-      run: bundle install
-    - name: Publish to RubyGems
-      env:
-        RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-      run: |
-        mkdir -p $HOME/.gem
-        echo -e "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}" > $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        gem build paperkite-rubocop.gemspec
-        gem push paperkite-rubocop-*.gem
+    - uses: rubygems/release-gem@v1


### PR DESCRIPTION
<!--
  This is the development/hotfix template, if doing a release or update PR, use the different
  templates from in Confluence:
  https://paperkite.atlassian.net/wiki/spaces/PWAP/pages/2370928641
-->
<!-- Update this with the JIRA ticket link -->


### 📝 Description
<!-- Describe the PR & explain the reason -->

One more time. Anyways, MFA enforcement is required so you can't use API keys for GHA anymore, you have to use this. Makes sense but woe is me.


### 🌳 Related PRs
<!-- List related PRs below or remove section if not used -->

- #18 
- #17 