### PR TITLE
Correct CI cache errors and gem release process

### DIFF
--- a/.github/workflows/rubygems-deployment.yaml
+++ b/.github/workflows/rubygems-deployment.yaml
@@ -15,4 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: 3.3
     - uses: rubygems/release-gem@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# OSX filesystem files
+*.DS_store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# Built gem
+pkg/
+
 # OSX filesystem files
 *.DS_store

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
-gem "rubocop", "~> 1.69.0"
-gem "rubocop-performance", "~> 1.23.0"
-gem "rubocop-rails", "~> 2.27.0"
-gem "rubocop-rspec", "~> 3.2.0"
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  ruby
   x86_64-darwin-20
   x86_64-darwin-22
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: .
+  specs:
+    paperkite-rubocop (1.4.0)
+      rubocop (~> 1.69.0)
+      rubocop-performance (~> 1.23.0)
+      rubocop-rails (~> 2.27.0)
+      rubocop-rspec (~> 3.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -21,6 +30,7 @@ GEM
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     drb (2.2.1)
+    gem-release (2.2.2)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.8.2)
@@ -34,6 +44,7 @@ GEM
     racc (1.8.1)
     rack (3.1.8)
     rainbow (3.1.1)
+    rake (13.2.1)
     regexp_parser (2.9.3)
     rubocop (1.69.0)
       json (~> 2.3)
@@ -75,10 +86,10 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
-  rubocop (~> 1.69.0)
-  rubocop-performance (~> 1.23.0)
-  rubocop-rails (~> 2.27.0)
-  rubocop-rspec (~> 3.2.0)
+  bundler (~> 2.5.23)
+  gem-release
+  paperkite-rubocop!
+  rake
 
 BUNDLED WITH
    2.5.23

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'bundler'
+Bundler::GemHelper.install_tasks

--- a/paperkite-rubocop.gemspec
+++ b/paperkite-rubocop.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |spec|
 
   spec.summary  = "PaperKite's shared Rubocop configuration"
   spec.homepage = "https://rubygems.org/paperkite/paperkite-rubocop"
-  spec.license  = "UNLICENSED"
 
   spec.files = [
     "config/base.yml",
@@ -16,6 +15,10 @@ Gem::Specification.new do |spec|
     "config/rails.yml",
     "config/rspec.yml"
   ]
+
+  spec.add_development_dependency "bundler", "~> 2.5.23"
+  spec.add_development_dependency "gem-release"
+  spec.add_development_dependency "rake"
 
   spec.add_dependency "rubocop",              "~> 1.69.0"
   spec.add_dependency "rubocop-performance",  "~> 1.23.0"


### PR DESCRIPTION
<!--
  This is the development/hotfix template, if doing a release or update PR, use the different
  templates from in Confluence:
  https://paperkite.atlassian.net/wiki/spaces/PWAP/pages/2370928641
-->
<!-- Update this with the JIRA ticket link -->


### 📝 Description
<!-- Describe the PR & explain the reason -->

Set up building and deploying the gem using `gem-release` which is needed for the CI workflow.

Some other bits:
- Source the gemfile from the gemspec
- Add missing dev deps

This works, tested by just forcing the tag onto this branch so I can stop making PRs to test (why I did that initially I'm not sure but here we are).

See:
- https://github.com/paperkite/paperkite-rubocop/actions/runs/12129083004


### 🌳 Related PRs
<!-- List related PRs below or remove section if not used -->

- #19 
- #18 
- #17 
